### PR TITLE
Add snapshot mechanism for dirty repos

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -215,7 +215,7 @@ ipcRenderer.on("selected:directory", (event, selectedDirectoryPath) => {
 ipcRenderer.on("init:done::updated-lists", (event, args) => {
   updateList("branches-list", args.branches);
   updateList("submodules-list", args.submodules);
-  if (args.submodules[0] === "No submodules in Repo") {
+  if (args.submodules.length === 0) {
     submoduleList.disabled = true;
     submoduleList.value = "No submodules in Repository";
   }

--- a/renderer.js
+++ b/renderer.js
@@ -231,8 +231,6 @@ ipcRenderer.on("init:done", () => {
   hideProcessingMessage();
 });
 
-
-
 ipcRenderer.on("init:error:invalid-repo-path", () => {
   branchList.disabled = submoduleList.disabled = true;
   hideProcessingMessage();
@@ -248,7 +246,7 @@ function sendOpwnDirectory() {
   ipcRenderer.send("open:directory");
 }
 
-ipcRenderer.on("error", (event, {message, error }) => {
+ipcRenderer.on("error", (event, { message, error }) => {
   // Hide the spinner
   hideProcessingMessage();
 
@@ -285,6 +283,43 @@ ipcRenderer.on("error", (event, {message, error }) => {
   const placeholder = document.getElementById("error-alert-placeholder");
   placeholder.innerHTML = ""; // Clear previous alerts if any
   placeholder.appendChild(alertDiv);
+});
+
+ipcRenderer.on("warning", (event, { message, action_button }) => {
+  console.log("Warning message received: ", message, action_button);
+  // Hide the spinner
+  hideProcessingMessage();
+
+  // Generate a unique ID for the button
+  const uniqueId = `action-button-${Date.now()}`;
+
+  // Create the alert div
+  const alertDiv = document.createElement("div");
+  alertDiv.className = "alert alert-warning alert-dismissible text-start";
+  alertDiv.role = "alert";
+
+  // Set the inner HTML of the alert with the title, message, and a "take action" button
+  alertDiv.innerHTML = `
+      <strong>Warning</strong>
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+      <p>${message}</p>
+      <button id="${uniqueId}" class="btn btn-primary">${action_button.label}</button>
+  `;
+
+  // Append the alert div to the placeholder
+  const placeholder = document.getElementById("error-alert-placeholder");
+  placeholder.innerHTML = ""; // Clear previous alerts if any
+  placeholder.appendChild(alertDiv);
+
+  // Optionally, add an event listener to the "take action" button
+  const actionButton = document.getElementById(uniqueId);
+  actionButton.addEventListener("click", () => {
+    ipcRenderer.send(action_button.action);
+    // Define what happens when the "take action" button is clicked
+    console.log("Take action button clicked");
+    // Hide the alert
+    alertDiv.style.display = "none";
+  });
 });
 
 document.getElementById("version-finder-form").addEventListener(

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,1 @@
+Hello World!

--- a/version_finder.js
+++ b/version_finder.js
@@ -228,6 +228,9 @@ class VersionFinder {
       // Iterate over all submodules
       console.log("this.submodules: ", this.submodules);
       for (const submodule of this.submodules) {
+        if(submodule === "No submodules in Repo"){
+          continue;
+        }
         const submodulePath = path.join(this.repositoryPath, submodule);
         console.log("submodulePath: ", submodulePath);
         const gitRepo = gitP(submodulePath);

--- a/version_finder.js
+++ b/version_finder.js
@@ -33,6 +33,7 @@ class VersionFinder {
     this.searchPatternRegex = null;
     this.isInitialized = false;
     this.hasChanges = false;
+    this.snapshot = null;
   }
 
   setSearchPattern(searchPattern) {
@@ -63,6 +64,9 @@ class VersionFinder {
    * @returns {Promise<Error|null>} - A promise that resolves to null if initialization is successful, or an Error object if there is an error.
    */
   async init() {
+    if (this.isInitialized) {
+      return;
+    }
     await this.git.checkIsRepo().then((isRepo) => {
       if (!isRepo) {
         throw new Error(
@@ -160,6 +164,132 @@ class VersionFinder {
       throw new Error("VersionFinder is not initialized.");
     }
     return this.submodules.includes(submodule);
+  }
+
+  async takeRepoSnapshot(gitRepo) {
+    const snapshot = {
+      commitHash: null,
+      branch: null,
+      stashId: null,
+    };
+    const status = await gitRepo.status();
+    if (status.files.length > 0) {
+      // Stash the changes
+      const stash = await gitRepo.stash(["save", "VersionFinder snapshot"]);
+      console.log("stash: ", stash);
+      // Get the id by fetching the list of stashes
+      const stashList = await gitRepo.stash(["list"]);
+      for (const stashEntry of stashList.split("\n")) {
+        console.log("stashEntry: ", stashEntry);
+        if (stashEntry.includes("VersionFinder snapshot")) {
+          snapshot.stashId = stashEntry.match(/stash@\{0\}/)[0];
+          break;
+        }
+      }
+    } else {
+      snapshot.stashId = null;
+    }
+    let branch = await gitRepo.revparse(["--abbrev-ref", "HEAD"]);
+    if (branch === "HEAD") {
+      branch = null;
+    }
+    const commitHash = await gitRepo.revparse(["HEAD"]);
+    snapshot.commitHash = commitHash;
+    snapshot.branch = branch;
+
+    return snapshot;
+  }
+
+  async saveRepoSnapshot() {
+    if (!this.isInitialized) {
+      throw new Error("VersionFinder is not initialized.");
+    }
+    console.log("In saveRepoSnapshot");
+    if (this.hasChanges) {
+      console.log("In saveRepoSnapshot: hasChanges");
+      /**
+       * Save the current state of the repository to a snapshot.
+       * Iterate over all submodules and save the current commit hash and branch name if exists.
+       * If a submodule has uncommited changes, stash the changes and save the stash id.
+       * Do the same for the main repository.
+       */
+      const snapshot = {
+        mainRepo: {
+          commitHash: "",
+          branch: "",
+          stashId: "",
+        },
+        submodules: {},
+      };
+
+      // Iterate over all submodules
+      console.log("this.submodules: ", this.submodules);
+      for (const submodule of this.submodules) {
+        const submodulePath = path.join(this.repositoryPath, submodule);
+        console.log("submodulePath: ", submodulePath);
+        const gitRepo = gitP(submodulePath);
+        snapshot.submodules[submodule] = await this.takeRepoSnapshot(gitRepo);
+      }
+
+      // Save the state of the main repository
+      snapshot.mainRepo = await this.takeRepoSnapshot(this.git);
+
+      // Save the snapshow to this.snapshot
+      this.snapshot = snapshot;
+      this.hasChanges = false;
+
+      console.log("snapshot: ", snapshot);
+    }
+  }
+
+  async restoreRepoSnapshot() {
+    if (!this.isInitialized) {
+      throw new Error("VersionFinder is not initialized.");
+    }
+    console.log("In restoreRepoSnapshot");
+    if (this.snapshot) {
+      console.log("In restoreRepoSnapshot: snapshot");
+      console.log("snapshot: ", this.snapshot);
+      /**
+       * Restore the repository to the state saved in the snapshot.
+       * Iterate over all submodules and restore the commit hash and branch name if exists.
+       * If a submodule had uncommited changes, restore the stash.
+       * Do the same for the main repository.
+       */
+      const snapshot = this.snapshot;
+
+      // Iterate over all submodules
+      for (const submodule of this.submodules) {
+        const submodulePath = path.join(this.repositoryPath, submodule);
+        const gitRepo = gitP(submodulePath);
+        const submoduleSnapshot = snapshot.submodules[submodule];
+        if (submoduleSnapshot.branch) {
+          await gitRepo.checkout(submoduleSnapshot.branch);
+        } else {
+          await gitRepo.checkout(submoduleSnapshot.commitHash);
+        }
+        if (submoduleSnapshot.stashId) {
+          // Restore the stash
+          await gitRepo.stash(["pop", submoduleSnapshot.stashId]);
+        }
+      }
+
+      // Restore the state of the main repository
+      const mainRepoSnapshot = snapshot.mainRepo;
+      if (mainRepoSnapshot.branch) {
+        await this.git.checkout(mainRepoSnapshot.branch);
+      } else {
+        await this.git.checkout(mainRepoSnapshot.commitHash);
+      }
+      if (mainRepoSnapshot.stashId) {
+        // Restore the stash
+        await this.git.stash(["pop", mainRepoSnapshot.stashId]);
+      }
+
+      // Clear the snapshot
+      this.snapshot = null;
+      this.hasChanges = true;
+    }
   }
 
   /**

--- a/version_finder.js
+++ b/version_finder.js
@@ -98,11 +98,11 @@ class VersionFinder {
           (line) => line.split(" ")[2]
         );
       } else {
-        this.submodules = ["No submodules in Repo"];
+        this.submodules = [];
       }
     } catch (e) {
       console.error("Error fetching submodule information.");
-      this.submodules = ["No submodules in Repo"];
+      this.submodules = [];
       throw e;
     }
 
@@ -228,9 +228,6 @@ class VersionFinder {
       // Iterate over all submodules
       console.log("this.submodules: ", this.submodules);
       for (const submodule of this.submodules) {
-        if(submodule === "No submodules in Repo"){
-          continue;
-        }
         const submodulePath = path.join(this.repositoryPath, submodule);
         console.log("submodulePath: ", submodulePath);
         const gitRepo = gitP(submodulePath);

--- a/version_finder.test.js
+++ b/version_finder.test.js
@@ -143,12 +143,13 @@ describe("VersionFinder: Repo with changes", () => {
   let versionFinderWithChanges;
 
   beforeEach(async () => {
-    versionFinderWithChanges = new VersionFinder();
-    await versionFinderWithChanges.init();
-
     // append a new line to this file
     const fs = require("fs");
     fs.appendFileSync(path.join(process.cwd(), "test.txt"), "\n");
+
+    versionFinderWithChanges = new VersionFinder();
+    await versionFinderWithChanges.init();
+
   });
 
   it("should throw an error of uncommitted changes", async () => {

--- a/version_finder.test.js
+++ b/version_finder.test.js
@@ -150,11 +150,11 @@ describe("VersionFinder: Repo with changes", () => {
     fs.writeFileSync("test.txt", "Hello World!");
   });
 
-  it("should throw an error of uncommitted changes", async () => {
+  it("should throw an error of unknown file", async () => {
     await expect(
       versionFinderWithChanges.getLogs("master", "test.txt")
     ).rejects.toThrow(
-      "The repository has uncommitted changes. Please commit or discard the changes before proceeding."
+      "error: pathspec 'master' did not match any file(s) known to git"
     );
   });
 });

--- a/version_finder.test.js
+++ b/version_finder.test.js
@@ -8,8 +8,8 @@ describe("VersionFinder: Constructor", () => {
     expect(versionFinder.repositoryPath).toBe(process.cwd());
   });
 
-  it('should throw an error if the provided path is not valid', () => {
-    const invalidPath = '/path/that/does/not/exist';
+  it("should throw an error if the provided path is not valid", () => {
+    const invalidPath = "/path/that/does/not/exist";
     expect(() => {
       new VersionFinder(invalidPath);
     }).toThrow('The provided path "/path/that/does/not/exist" does not exist.');
@@ -20,9 +20,7 @@ describe("VersionFinder: Constructor", () => {
     const notRepoVersionFinder = new VersionFinder(noRepoPath);
     await expect(async () => {
       await notRepoVersionFinder.init();
-    }).rejects.toThrow(
-      "The given path / is Not a git repository"
-    );
+    }).rejects.toThrow("The given path / is Not a git repository");
   });
 });
 
@@ -137,5 +135,26 @@ describe("VersionFinder: Initialized", () => {
       invalidSubmodule
     );
     expect(isInvalidSubmodule).toBe(false);
+  });
+});
+
+describe("VersionFinder: Repo with changes", () => {
+  let versionFinderWithChanges;
+
+  beforeEach(async () => {
+    versionFinderWithChanges = new VersionFinder();
+    await versionFinderWithChanges.init();
+
+    // Create a new file
+    const fs = require("fs");
+    fs.writeFileSync("test.txt", "Hello World!");
+  });
+
+  it("should throw an error of uncommitted changes", async () => {
+    await expect(
+      versionFinderWithChanges.getLogs("master", "test.txt")
+    ).rejects.toThrow(
+      "The repository has uncommitted changes. Please commit or discard the changes before proceeding."
+    );
   });
 });

--- a/version_finder.test.js
+++ b/version_finder.test.js
@@ -158,11 +158,37 @@ describe("VersionFinder: Repo with changes", () => {
     fs.writeFileSync(path.join(process.cwd(), "test.txt"), "Hello World!");
   });
 
-  it("should throw an error of uncommitted changes", async () => {
+  it("should throw an error of uncommitted changes when calling getLogs", async () => {
     await expect(
       versionFinderWithChanges.getLogs("master", "test.txt")
     ).rejects.toThrow(
       "The repository has uncommitted changes. Please commit or discard the changes before proceeding."
     );
   });
+
+  it("should throw an error of uncommitted changes when calling getFirstCommitSha", async () => {
+    await expect(
+      versionFinderWithChanges.getFirstCommitSha("master", "test.txt")
+    ).rejects.toThrow(
+      "The repository has uncommitted changes. Please commit or discard the changes before proceeding."
+    );
+  });
+
+  it("should throw an error of uncommitted changes when calling isValidCommitSha", async () => {
+    await expect(
+      versionFinderWithChanges.isValidCommitSha("master", "test.txt")
+    ).rejects.toThrow(
+      "The repository has uncommitted changes. Please commit or discard the changes before proceeding."
+    );
+  });
+
+  it("should throw an error of uncommitted changes when calling getFirstCommitWithVersion", async () => {
+    await expect(
+      versionFinderWithChanges.getFirstCommitWithVersion("master", "test.txt")
+    ).rejects.toThrow(
+      "The repository has uncommitted changes. Please commit or discard the changes before proceeding."
+    );
+  });
+
+
 });

--- a/version_finder.test.js
+++ b/version_finder.test.js
@@ -190,5 +190,16 @@ describe("VersionFinder: Repo with changes", () => {
     );
   });
 
+  it("should indicate the repository is dirty", async () => {
+    const isDirty = await versionFinderWithChanges.isRepoDirty(versionFinderWithChanges.git);
+    expect(isDirty).toBe(true);
+  });
+
+  it("should save repo snapshot", async () => {
+    await versionFinderWithChanges.saveRepoSnapshot();
+    const isDirty = await versionFinderWithChanges.isRepoDirty(versionFinderWithChanges.git);
+    expect(isDirty).toBe(false);
+  });
+
 
 });

--- a/version_finder.test.js
+++ b/version_finder.test.js
@@ -145,7 +145,7 @@ describe("VersionFinder: Repo with changes", () => {
   beforeEach(async () => {
     // append a new line to this file
     const fs = require("fs");
-    fs.appendFileSync(path.join(process.cwd(), "test.txt"), "\n");
+    fs.writeFileSync(path.join(process.cwd(), "test.txt"), "I am a changed file!");
 
     versionFinderWithChanges = new VersionFinder();
     await versionFinderWithChanges.init();
@@ -155,7 +155,7 @@ describe("VersionFinder: Repo with changes", () => {
   afterEach(() => {
     // remove the new line added to this file
     const fs = require("fs");
-    fs.truncateSync(path.join(process.cwd(), "test.txt"), 0);
+    fs.writeFileSync(path.join(process.cwd(), "test.txt"), "Hello World!");
   });
 
   it("should throw an error of uncommitted changes", async () => {

--- a/version_finder.test.js
+++ b/version_finder.test.js
@@ -152,6 +152,12 @@ describe("VersionFinder: Repo with changes", () => {
 
   });
 
+  afterEach(() => {
+    // remove the new line added to this file
+    const fs = require("fs");
+    fs.truncateSync(path.join(process.cwd(), "test.txt"), 0);
+  });
+
   it("should throw an error of uncommitted changes", async () => {
     await expect(
       versionFinderWithChanges.getLogs("master", "test.txt")

--- a/version_finder.test.js
+++ b/version_finder.test.js
@@ -195,10 +195,19 @@ describe("VersionFinder: Repo with changes", () => {
     expect(isDirty).toBe(true);
   });
 
-  it("should save repo snapshot", async () => {
+  it("should saveRepoSnapshot and indicate repo is clean", async () => {
     await versionFinderWithChanges.saveRepoSnapshot();
     const isDirty = await versionFinderWithChanges.isRepoDirty(versionFinderWithChanges.git);
     expect(isDirty).toBe(false);
+  });
+
+  it("should saveRepoSnapshot and indicate repo is clean then restore", async () => {
+    await versionFinderWithChanges.saveRepoSnapshot();
+    const isDirty = await versionFinderWithChanges.isRepoDirty(versionFinderWithChanges.git);
+    expect(isDirty).toBe(false);
+    await versionFinderWithChanges.restoreRepoSnapshot();
+    const isDirtyAfterRestore = await versionFinderWithChanges.isRepoDirty(versionFinderWithChanges.git);
+    expect(isDirtyAfterRestore).toBe(true);
   });
 
 

--- a/version_finder.test.js
+++ b/version_finder.test.js
@@ -1,3 +1,4 @@
+const path = require("path");
 const { VersionFinder } = require("./version_finder");
 
 describe("VersionFinder: Constructor", () => {
@@ -145,16 +146,16 @@ describe("VersionFinder: Repo with changes", () => {
     versionFinderWithChanges = new VersionFinder();
     await versionFinderWithChanges.init();
 
-    // Create a new file
+    // append a new line to this file
     const fs = require("fs");
-    fs.writeFileSync("test.txt", "Hello World!");
+    fs.appendFileSync(path.join(process.cwd(), "test.txt"), "\n");
   });
 
-  it("should throw an error of unknown file", async () => {
+  it("should throw an error of uncommitted changes", async () => {
     await expect(
       versionFinderWithChanges.getLogs("master", "test.txt")
     ).rejects.toThrow(
-      "error: pathspec 'master' did not match any file(s) known to git"
+      "The repository has uncommitted changes. Please commit or discard the changes before proceeding."
     );
   });
 });


### PR DESCRIPTION
This pull request adds a snapshot mechanism for dirty repositories. The mechanism stashes any changes and saves the current commit hash. After performing the necessary operations, it restores the repository to its previous state. This ensures that the repository remains in a clean state and prevents any unintended changes from being committed.